### PR TITLE
Comment out Terraform backend configuration

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,9 +1,9 @@
-terraform {
-  backend "azurerm" {
-    resource_group_name   = "rg-cdo-dev"
-    storage_account_name  = "backendterraformstate1"
-    container_name        = "terraform-state"
-    key                   = "terraform.tfstate"
+# terraform {
+#   backend "azurerm" {
+#     resource_group_name   = "rg-cdo-dev"
+#     storage_account_name  = "backendterraformstate1"
+#     container_name        = "terraform-state"
+#     key                   = "terraform.tfstate"
     
-  }
-}
+#   }
+# }


### PR DESCRIPTION
The azurerm backend block in backend.tf has been commented out, likely to disable remote state management or allow local state usage for development or testing purposes.